### PR TITLE
Fixes bug in dependency solver cache.

### DIFF
--- a/demonstrate_extractor.py
+++ b/demonstrate_extractor.py
@@ -58,8 +58,8 @@ features = [added_badwords_ratio, added_misspellings_ratio,
             words_removed]
 
 print("Extracting features for "  +
-      "https://pt.wikipedia.org/w/index.php?diff=40837209")
-values = api_extractor.extract(40837209, features)
+      "https://pt.wikipedia.org/w/index.php?diff=4083720")
+values = api_extractor.extract(4083720, features)
 
 for feature, value in zip(features, values):
     print("{0}: {1}".format(feature, value))

--- a/revscoring/extractors/api.py
+++ b/revscoring/extractors/api.py
@@ -1,4 +1,4 @@
-from ..dependent import solve
+from ..dependent import solve_many
 from .extractor import Extractor
 
 
@@ -17,4 +17,4 @@ class APIExtractor(Extractor):
                       'session': self.session,
                       'language': self.language})
         
-        return [solve(feature, cache) for feature in features]
+        return solve_many(features, cache=cache)

--- a/revscoring/tests/test_dependent.py
+++ b/revscoring/tests/test_dependent.py
@@ -1,0 +1,20 @@
+from nose.tools import eq_
+
+from ..dependent import Dependent, solve, solve_many
+
+
+def test_solve():
+    
+    foo = Dependent("foo", lambda: "foo")
+    bar = Dependent("bar", lambda foo: foo + "bar", dependencies=[foo])
+    
+    eq_(solve(bar), "foobar")
+    
+def test_solve_many():
+    
+    foo = Dependent("foo", lambda: "foo")
+    bar = Dependent("bar", lambda foo: foo + "bar", dependencies=[foo])
+    
+    eq_(list(solve_many([bar, foo, bar])), ["foobar", "foo", "foobar"])
+    eq_(foo.calls, 1)
+    eq_(bar.calls, 1)


### PR DESCRIPTION
The old dependency solver would repeat computations when solving multiple dependencies.  

This commit adds solve_many() to preserve the cache and a test to make sure that it works as expected.