### PR TITLE
Switches to the use of enchant for looking up misspellings and adds misspellings feature for farsi. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Feature extraction:
     .. code-block:: python
 
         >>> from mw.api import Session
-        >>> 
+        >>>
         >>> from revscoring.extractors import APIExtractor
         >>> from revscoring.features import diff, parent_revision, revision, user
         >>>
@@ -101,11 +101,11 @@ system.  These are for ``scipy`` and ``numpy``.
 
 Linux Mint 17.1:
 
-1. ``sudo apt-get install g++ gfortran liblapack-dev python3-dev``
+1. ``sudo apt-get install g++ gfortran liblapack-dev python3-dev myspell-pt myspell-fa myspell-en``
 
 Ubuntu 14.04:
 
-1. ``sudo apt-get install g++ gfortran liblapack-dev libopenblas-dev python3-dev``
+1. ``sudo apt-get install g++ gfortran liblapack-dev libopenblas-dev python3-dev myspell-pt myspell-fa myspell-en``
 
 Authors
 =======

--- a/README.rst
+++ b/README.rst
@@ -101,11 +101,11 @@ system.  These are for ``scipy`` and ``numpy``.
 
 Linux Mint 17.1:
 
-1. ``sudo apt-get install g++ gfortran liblapack-dev python3-dev myspell-pt myspell-fa myspell-en``
+1. ``sudo apt-get install g++ gfortran liblapack-dev python3-dev myspell-pt myspell-fa myspell-en-au  myspell-en-gb  myspell-en-us  myspell-en-za``
 
 Ubuntu 14.04:
 
-1. ``sudo apt-get install g++ gfortran liblapack-dev libopenblas-dev python3-dev myspell-pt myspell-fa myspell-en``
+1. ``sudo apt-get install g++ gfortran liblapack-dev libopenblas-dev python3-dev myspell-pt myspell-fa myspell-en-au  myspell-en-gb  myspell-en-us  myspell-en-za``
 
 Authors
 =======

--- a/revscoring/languages/english.py
+++ b/revscoring/languages/english.py
@@ -1,6 +1,7 @@
 import warnings
 
-from nltk.corpus import stopwords, wordnet
+import enchant
+from nltk.corpus import stopwords
 from nltk.stem.snowball import SnowballStemmer
 
 from .language import Language, LanguageUtility
@@ -34,7 +35,8 @@ BADWORDS = set([
     "yank", "yankee", "yid",
     "zipperhead"
 ])
-STEMMED_BADWORDS = set(STEMMER.stem(w) for w in BADWORDS)
+STEMMMED_BADWORDS = set(STEMMER.stem(w) for w in BADWORDS)
+DICTIONARY = enchant.Dict("en")
 
 def stem_word_process():
     def stem_word(word):
@@ -51,10 +53,9 @@ is_badword = LanguageUtility("is_badword", is_badword_process, depends_on=[stem_
 
 def is_misspelled_process():
     def is_misspelled(word):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            return len(wordnet.synsets(word)) == 0
+        return not DICTIONARY.check(word)
     return is_misspelled
+
 is_misspelled = LanguageUtility("is_misspelled", is_misspelled_process,
                                 depends_on=[])
 

--- a/revscoring/languages/english.py
+++ b/revscoring/languages/english.py
@@ -35,7 +35,7 @@ BADWORDS = set([
     "yank", "yankee", "yid",
     "zipperhead"
 ])
-STEMMMED_BADWORDS = set(STEMMER.stem(w) for w in BADWORDS)
+STEMMED_BADWORDS = set(STEMMER.stem(w) for w in BADWORDS)
 DICTIONARY = enchant.Dict("en")
 
 def stem_word_process():

--- a/revscoring/languages/farsi.py
+++ b/revscoring/languages/farsi.py
@@ -14,4 +14,4 @@ def is_misspelled_process():
 is_misspelled = LanguageUtility("is_misspelled", is_misspelled_process,
                                 depends_on=[])
 
-english = Language("revscoring.languages.english", [is_misspelled])
+english = Language("revscoring.languages.farsi", [is_misspelled])

--- a/revscoring/languages/farsi.py
+++ b/revscoring/languages/farsi.py
@@ -14,4 +14,4 @@ def is_misspelled_process():
 is_misspelled = LanguageUtility("is_misspelled", is_misspelled_process,
                                 depends_on=[])
 
-english = Language("revscoring.languages.farsi", [is_misspelled])
+farsi = Language("revscoring.languages.farsi", [is_misspelled])

--- a/revscoring/languages/farsi.py
+++ b/revscoring/languages/farsi.py
@@ -1,0 +1,17 @@
+import warnings
+
+import enchant
+
+from .language import Language, LanguageUtility
+
+DICTIONARY = enchant.Dict("fa")
+
+def is_misspelled_process():
+    def is_misspelled(word):
+        return not DICTIONARY.check(word)
+    return is_misspelled
+
+is_misspelled = LanguageUtility("is_misspelled", is_misspelled_process,
+                                depends_on=[])
+
+english = Language("revscoring.languages.english", [is_misspelled])

--- a/revscoring/languages/persian.py
+++ b/revscoring/languages/persian.py
@@ -14,4 +14,4 @@ def is_misspelled_process():
 is_misspelled = LanguageUtility("is_misspelled", is_misspelled_process,
                                 depends_on=[])
 
-farsi = Language("revscoring.languages.farsi", [is_misspelled])
+persian = Language("revscoring.languages.persian", [is_misspelled])

--- a/revscoring/languages/portuguese.py
+++ b/revscoring/languages/portuguese.py
@@ -1,6 +1,7 @@
 import warnings
 
-from nltk.corpus import stopwords, wordnet
+import enchant
+from nltk.corpus import stopwords
 from nltk.stem.snowball import SnowballStemmer
 
 from .language import Language, LanguageUtility
@@ -183,6 +184,7 @@ BADWORDS = set([
     "zipi", "zizi", "zoando", "zoar", "zoeira", "zuando", "zuar", "zueira"
 ])
 STEMMED_BADWORDS = set(STEMMER.stem(w) for w in BADWORDS)
+DICTIONARY = enchant.Dict("pt")
 
 def stem_word_process():
     def stem_word(word):
@@ -200,12 +202,7 @@ is_badword = LanguageUtility("is_badword", is_badword_process,
 
 def is_misspelled_process():
     def is_misspelled(word):
-        if word.lower() in STOPWORDS: return False
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-
-            return len(wordnet.synsets(word, lang="por")) == 0
+        return not DICTIONARY.check(word)
     return is_misspelled
 is_misspelled = LanguageUtility("is_misspelled", is_misspelled_process,
                                 depends_on=[])

--- a/revscoring/languages/tests/test_farsi.py
+++ b/revscoring/languages/tests/test_farsi.py
@@ -1,0 +1,8 @@
+from nose.tools import eq_
+
+from ..farsi import is_misspelled
+
+
+def test_language():
+    assert is_misspelled()("Notafarsiword")
+    assert not is_misspelled()("مهم")


### PR DESCRIPTION
This affords a substantial performance improvement.  

$ python demonstrate_spelling_speed.py 
Sending requests with default User-Agent.  Set 'user_agent' on api.Session to quiet this message.
Wordnet check took 8.90493106842041 seconds
Enchant check took 0.03188371658325195 seconds



