### PR TITLE
Bump down scipy version to 0.13.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pytz == 2015.4
 requests == 2.5.3
 setuptools == 15.1
 pyenchant == 1.6.6
-scipy == 0.15.1
+scipy == 0.13.3
 scikit-learn == 0.15.2
 yamlconf == 0.0.1


### PR DESCRIPTION
Matches version in ubuntu trusty, allows us to not depend on pip to install scipy